### PR TITLE
chore: avoid using relative paths

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: cd apps && panel serve --address="0.0.0.0" --port=$PORT *.py --allow-websocket-origin=tec-hatch-demo.herokuapp.com --allow-websocket-origin=dev-tec-hatch-demo.herokuapp.com
+web: panel serve --address="0.0.0.0" --port=$PORT apps/*.py --allow-websocket-origin=tec-hatch-demo.herokuapp.com --allow-websocket-origin=dev-tec-hatch-demo.herokuapp.com

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ This dashboard is a tool to collect community opinions on the proper parameteriz
 
 ```
 pip3 install -r requirements.txt
+pip install -e ./
 jupyter labextension install @pyviz/jupyterlab_pyviz
 ```
 
 ## Running Locally
 
 ```
-cd apps
-panel serve --show *.py
+panel serve --show apps/hatch.py [--dev tech/* apps/*]
 ```
 
 ## Resources

--- a/apps/hatch.py
+++ b/apps/hatch.py
@@ -14,15 +14,13 @@ import codecs
 import sys
 import os
 
-sys.path.append('..')
-
 from tech.tech import read_impact_hour_data, read_cstk_data, TECH
 from tech.tech import ImpactHoursData, ImpactHoursFormula, Hatch, DandelionVoting
 import tech.config_bounds as config_bounds
 
 load_dotenv()
 
-env = Environment(loader=FileSystemLoader('..'))
+env = Environment(loader=FileSystemLoader('.'))
 template = env.get_template('template/index.html')
 
 # API settings

--- a/apps/test-hatch.py
+++ b/apps/test-hatch.py
@@ -13,15 +13,13 @@ import codecs
 import sys
 import os
 
-sys.path.append('..')
-
 from tech.tech import read_impact_hour_data, read_cstk_data, TECH
 from tech.tech import ImpactHoursData, ImpactHoursFormula, Hatch, DandelionVoting
 import tech.config_bounds as config_bounds
 
 load_dotenv()
 
-env = Environment(loader=FileSystemLoader('..'))
+env = Environment(loader=FileSystemLoader('.'))
 template = env.get_template('template/index.html')
 
 # API settings

--- a/tech/tech.py
+++ b/tech/tech.py
@@ -34,7 +34,7 @@ sheets = {i:sheet for i, sheet in enumerate(sheets)}
 
 def read_excel(sheet_name="Total Impact Hours so far", header=1, index_col=0, usecols=None) -> pd.DataFrame:
     data = pd.read_excel(
-            os.path.join('../', "data", "TEC Praise Quantification.xlsx"),
+            os.path.join("data", "TEC Praise Quantification.xlsx"),
             sheet_name=sheet_name,
             engine='openpyxl',
             header=header,
@@ -52,7 +52,7 @@ def read_impact_hour_data():
 
 def read_cstk_data():
     # Load CSTK data
-    cstk_data = pd.read_csv('../data/CSTK_DATA.csv', header=None).reset_index().head(100)
+    cstk_data = pd.read_csv('data/CSTK_DATA.csv', header=None).reset_index().head(100)
     cstk_data.columns = ['CSTK Token Holders', 'CSTK Tokens']
     cstk_data['CSTK Tokens Capped'] = cstk_data['CSTK Tokens'].apply(lambda x: min(x, cstk_data['CSTK Tokens'].sum()/10))
     return cstk_data
@@ -362,8 +362,8 @@ class TECH(param.Parameterized):
 
 
 class ImpactHoursData(param.Parameterized):
-    historic = pd.read_csv('../data/IHPredictions.csv').query('Model=="Historic"')
-    optimistic = pd.read_csv('../data/IHPredictions.csv').query('Model=="Optimistic"')
+    historic = pd.read_csv('data/IHPredictions.csv').query('Model=="Historic"')
+    optimistic = pd.read_csv('data/IHPredictions.csv').query('Model=="Optimistic"')
     predicted_hours = param.Number(0.5, bounds=(-.5,1.5), step=0.05)
     #total_impact_hours = param.Integer(step=100)
 


### PR DESCRIPTION
This PR removes relative path usage, so data & templates are always read from the base path